### PR TITLE
Fix: Change cash balance activity query to use updated_at instead of …

### DIFF
--- a/server.js
+++ b/server.js
@@ -1755,7 +1755,7 @@ app.get('/api/activity', requireAuth, async (req, res) => {
                     'Set cash balance' as description,
                     cb.initial_balance as amount,
                     'Cash' as account_info,
-                    cb.created_at as activity_date,
+                    cb.updated_at as activity_date,
                     'created' as action_type
                 FROM cash_balance cb
                 WHERE cb.user_id = $1 AND cb.initial_balance > 0


### PR DESCRIPTION
…created_at

- Cash balance table only has updated_at column, not created_at
- Changed activity query to reference cb.updated_at for consistency
- Resolves Railway deployment error: column cb.created_at does not exist